### PR TITLE
Added after build hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ export interface PluginOptions {
   // You can transform declaration file-path and content through it
   // Default: () => {}
   beforeWriteFile?: (filePath: string, content: string) => void | TransformWriteFile
+
+  // After build hook
+  // Default: () => {}
+  afterBuild?: () => void
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,8 @@ export interface PluginOptions {
   skipDiagnostics?: boolean,
   logDiagnostics?: boolean,
   afterDiagnostic?: (diagnostics: Diagnostic[]) => void,
-  beforeWriteFile?: (filePath: string, content: string) => void | TransformWriteFile
+  beforeWriteFile?: (filePath: string, content: string) => void | TransformWriteFile,
+  afterBuild?: () => void
 }
 
 const noneExport = 'export {};\n'
@@ -66,7 +67,8 @@ export default function dtsPlugin(options: PluginOptions = {}): Plugin {
     skipDiagnostics = true,
     logDiagnostics = false,
     afterDiagnostic = noop,
-    beforeWriteFile = noop
+    beforeWriteFile = noop,
+    afterBuild = noop
   } = options
 
   const compilerOptions = options.compilerOptions ?? {}
@@ -363,6 +365,10 @@ export default function dtsPlugin(options: PluginOptions = {}): Plugin {
           `${chalk.cyan('[vite:dts]')} Declaration files built in ${Date.now() - startTime}ms.\n`
         )
       )
+
+      if (typeof afterBuild === 'function') {
+        afterBuild()
+      }
     }
   }
 }


### PR DESCRIPTION
The motivation:

I was trying to add https://api-extractor.com/ to a project which rolls-up all the .d.ts definitions into single file. Many open source projects use this tool. 

When running one time `vite build` it's easy doable, because it's easy to make via `vite build && node/buildTypes.js`, but this doesn't work if you want to run vite build in watch mode.

The limitation was that even if define that command as a rollup plugin it get's called before all files were written (even with enforce: 'post' option).

So maybe having a afterBuild hook should give an option to run api-extractor after all files were written.

P.s. As always, thanks for this lib and your work! :)