### PR TITLE
feat: add `aliasesExclude` configuration

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       outputDir: 'types',
       // include: ['src/index.ts'],
       exclude: ['src/ignore'],
+      aliasesExclude: ['@components'],
       staticImport: true,
       // skipDiagnostics: false,
       // logDiagnostics: true,


### PR DESCRIPTION
Add `aliasesExclude` configuration to control not transforming aliases path.