### PR TITLE
修复如果入口文件不存在 export default object; 形式的导出 那么在生成.d.ts文件报错问题

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -428,7 +428,7 @@ export function dtsPlugin(options: PluginOptions = {}): Plugin {
           filePath = filePath.replace(tsRE, '')
           filePath = fullRelativeRE.test(filePath) ? filePath : `./${filePath}`
 
-          let content = `import ${libName} from '${filePath}'\nexport default ${libName}\nexport * from '${filePath}'\n`
+          let content = `export * from '${filePath}'\n`
 
           if (typeof beforeWriteFile === 'function') {
             const result = beforeWriteFile(typesPath, content)


### PR DESCRIPTION
修复如果入口文件不存在 export default object; 形式的导出 那么在生成.d.ts文件的时候就会报
Error: Internal Error: Unable to analyze the export "default" in
D:/learn-project/vite-plugin-dts-main/example/types/src/index.d.ts 的错误

Fixes https://github.com/qmhc/vite-plugin-dts/issues/69