### PR TITLE
fix: incorrect compiler address resolution

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -20,7 +20,11 @@ function requireCompiler() {
     if (compileRoot) {
       try {
         compiler = _require(_require.resolve('vue/compiler-sfc', { paths: [compileRoot] }))
-      } catch (e) {}
+      } catch (e) {
+        try {
+          compiler = _require(_require.resolve('@vue/compiler-sfc', { paths: [compileRoot] }))
+        } catch (e) {}
+      }
     }
 
     if (!compiler) {


### PR DESCRIPTION
Hi, in vue 2.6x project, the compiler get a wrong address resolution from global node_modules but not from my project.

case:
project: vue@2.6.14
global: vue@2.7.13

It will get the global node_modules(`${global}/node_modules/vue/compiler-sfc`) , not from my project node_modules(`${project}/node_modules/@vue/compiler-sfc`)
