### PR TITLE
fix: add types export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     }


### PR DESCRIPTION
## Problem description

Hi! I noticed that in my project, TypeScript cannot infer the types of this plugin.

![image](https://user-images.githubusercontent.com/16900547/198947353-8b09b952-9ced-4691-9e73-d0e2323976bc.png)
![image](https://user-images.githubusercontent.com/16900547/198947387-0af36a73-fe64-47db-aff6-41dd9166b853.png)

But if you add the `types` export, it starts to work.

![image](https://user-images.githubusercontent.com/16900547/198947657-ef29cb72-89a9-4bde-b170-0317ad5cc48b.png)
![image](https://user-images.githubusercontent.com/16900547/198947678-2c9dcfc9-df9c-4b6f-bf7c-1f20cd6cfb16.png)

> Note that the `types` export **has** to be the first entry in an exports object

My typescript config for reference:

```json
{
	"$schema": "https://json.schemastore.org/tsconfig",
	"display": "base",
	"compileOnSave": false,
	"compilerOptions": {
		"composite": false,
		"target": "es2020",
		"module": "es2022",
		"lib": ["es2022", "dom"],
		"sourceMap": true,
		"declaration": true,
		"declarationMap": true,
		"noUnusedLocals": false,
		"moduleResolution": "nodenext",
		"esModuleInterop": true,
		"allowSyntheticDefaultImports": true,
		"emitDecoratorMetadata": true,
		"experimentalDecorators": true,
		"importHelpers": true,
		"inlineSources": false,
		"isolatedModules": true,
		"resolveJsonModule": true,
		"skipLibCheck": true,
		"skipDefaultLibCheck": true,
		"checkJs": true,
		"preserveWatchOutput": true,
		"baseUrl": ".",
		"strict": true,
		"forceConsistentCasingInFileNames": true,
		"importsNotUsedAsValues": "error"
	},
	"include": [],
	"exclude": ["node_modules", "tmp", "dist", "coverage"]
}
```

The important setting here is: `"moduleResolution": "nodenext"`, and that my package.json is set to `"type": "module"`

## Solution

Add `"types": "./dist/index.d.ts",` to the package.json