### PR TITLE
fix: compilation missing plugin "decorators-legacy"

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -130,7 +130,7 @@ export function compileVueCode(code: string) {
       content = rewriteDefault(
         script.content,
         '_sfc_main',
-        script.lang === 'ts' ? ['typescript'] : undefined
+        script.lang === 'ts' ? ['typescript', 'decorators-legacy'] : undefined
       )
       content += '\nexport default _sfc_main\n'
 


### PR DESCRIPTION
项目中使用了装饰器，发现会报错

```
[vite:dts] This experimental syntax requires enabling one of the following parser plugin(s): "decorators", "decorators-legacy".
```

对比 `@vue/compiler-sfc` 和上面处理  script setup 的部分发现是漏了 `decorators-legacy`，补上后解决问题