### PR TITLE
fix: mark typescript as external dependency

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -2,7 +2,7 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   entries: ['src/index'],
-  externals: ['vite', 'vue/compiler-sfc', '@vue/compiler-sfc'],
+  externals: ['vite', 'vue/compiler-sfc', '@vue/compiler-sfc', 'typescript'],
   clean: true,
   declaration: true,
   rollup: {


### PR DESCRIPTION
Mark `typescript` as an external dependency, so that it doesn't end up in the bundled code.

|before|after|
|--|--|
| ![image](https://user-images.githubusercontent.com/6443113/209136780-bca803ff-61cf-4423-9bb7-0ba535ab1ddd.png) |  ![image](https://user-images.githubusercontent.com/6443113/209136815-c3abb709-6b10-405b-94e2-1aa896743be0.png) |

