### PR TITLE
fix: include .d.ts extension in multiple outputs

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -438,7 +438,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
         const typesPath = types ? resolve(root, types) : resolve(outputDir, indexName)
 
         for (const name of entryNames) {
-          let filePath = multiple ? resolve(outputDir, name.replace(tsRE, '.d.ts')) : typesPath
+          let filePath = multiple ? resolve(outputDir, `${name}.d.ts`) : typesPath
 
           if (fs.existsSync(filePath)) continue
 


### PR DESCRIPTION
Fix for this comment https://github.com/qmhc/vite-plugin-dts/issues/136#issuecomment-1356681237
Perhaps it also fixes this issue https://github.com/qmhc/vite-plugin-dts/issues/144

### Problem
With multiple entries, `name` equals the name of the input, which doesn't include any file extension. Therefore, the `tsRe` regex doesn't work.
### Fix
Add `.d.ts` extension manually to these entries