### PR TITLE
chore: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ export interface PluginOptions {
   /**
    * Manual set exclude glob
    *
-   * Defaults base on your tsconfig.json exclude option, be 'node_module/**' when empty
+   * Defaults base on your tsconfig.json exclude option, be 'node_modules/**' when empty
    */
   exclude?: string | string[]
 


### PR DESCRIPTION
起因是使用插件时没传 `exclude` 字段结果编译结果包含了 `node_modules` ，以为是代码问题，查阅源码后重新排查发现是项目配置的 `tsconfig.json` 被误改了。

在此个人想法是最终的 `exclude` 属性应该始终排除 `node_modules` ，借此 PR 简单讨论下，倾听下更优的看法