### PR TITLE
feat: compatible with svelte

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,6 +34,7 @@ import type { PluginOptions } from './types'
 
 const noneExport = 'export {};\n'
 const vueRE = /\.vue$/
+const svelteRE = /\.svelte$/
 const tsRE = /\.(m|c)?tsx?$/
 const jsRE = /\.(m|c)?jsx?$/
 const dtsRE = /\.d\.(m|c)?tsx?$/
@@ -44,7 +45,7 @@ const watchExtensionRE = /\.(vue|(m|c)?(t|j)sx?)$/
 const fullRelativeRE = /^\.\.?\//
 const defaultIndex = 'index.d.ts'
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {}
+const noop = () => { }
 const extPrefix = (file: string) => (mtjsRE.test(file) ? 'm' : ctjsRE.test(file) ? 'c' : '')
 const resolve = (...paths: string[]) => normalizePath(_resolve(...paths))
 
@@ -125,6 +126,9 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
       }
     } else if (!id.includes('.vue?vue') && (tsRE.test(id) || (allowJs && jsRE.test(id)))) {
       project.createSourceFile(id, await fs.readFile(id, 'utf-8'), { overwrite: true })
+    } else if (svelteRE.test(id)) {
+      const content = 'export { SvelteComponentTyped as default } from \'svelte/internal\';'
+      project.createSourceFile(`${id}.ts`, content, { overwrite: true })
     }
   }
 


### PR DESCRIPTION
I added small change so that it will be compatible with Svelte Frameworks.
It will look for .svelte files and create declaration file that looks like
```
export { SvelteComponentTyped as default } from 'svelte/internal';
```