### PR TITLE
FEATURE Enable docModel support

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -52,7 +52,8 @@ export function rollupDeclarationFiles({
         reportFileName: '<unscopedPackageName>.api.md'
       },
       docModel: {
-        enabled: false
+        enabled: true,
+        apiJsonFilePath: '<projectFolder>/docs/<unscopedPackageName>.api.json'
       },
       dtsRollup: {
         enabled: true,


### PR DESCRIPTION
This PR enables the capability of api-extractor to output a 'docModel' file which includes both type information and decorator metadata into a JSON file which can be used to generate library documentation.  This implementation outputs the file to a 'docs' folder in the project root.

There is no existing way to enable this option via the config - although that could be desirable behavior. This PR hardcodes the additional output.  In the future, making some of the api-extractor options configurable via `dts()` could make sense.