### PR TITLE
fix: fails to generate declarationMaps

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -377,8 +377,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
         const sourceFile = program.getSourceFile(id)
 
         if (sourceFile) {
-          for (const outputFile of service.getEmitOutput(sourceFile.fileName, true, true)
-            .outputFiles) {
+          for (const outputFile of service.getEmitOutput(sourceFile.fileName, true).outputFiles) {
             outputFiles.set(
               resolve(publicRoot, relative(outDir, ensureAbsolute(outputFile.name, outDir))),
               outputFile.text


### PR DESCRIPTION
resolves #259 

I found that #259 happens after https://github.com/qmhc/vite-plugin-dts/commit/284c77ff65741f2cddbca3eba380b4a624cec3c7.

I just restored this change from the latest (63321c2be82f02b543ec17460133b00d209fffd3),
which makes it generate `.map` files for `.d.ts` files well (checked on bac2a7d3b1fec753706c35b2681163690ecaec81).

and It seems #254 is not reproduced 🤔(checked on b041a4c).
![not-reproduce- 254](https://github.com/qmhc/vite-plugin-dts/assets/40269597/ba29b605-9059-4dc7-9224-1e69f969b71b)