### PR TITLE
fix: minor typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ export interface PluginOptions {
   /**
    * Override `exclude` glob
    *
-   * Defaults to `exclude` property of tsconfig.json or `'node_module/**'` if not supplied.
+   * Defaults to `exclude` property of tsconfig.json or `'node_modules/**'` if not supplied.
    */
   exclude?: string | string[],
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -231,7 +231,7 @@ export interface PluginOptions {
   /**
    * 手动设置排除路径的 glob
    *
-   * 默认基于 tsconfig.json 的 `exclude` 选线，未设置时为 `'node_module/**'`
+   * 默认基于 tsconfig.json 的 `exclude` 选线，未设置时为 `'node_modules/**'`
    */
   exclude?: string | string[],
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface PluginOptions {
   /**
    * Override `exclude` glob
    *
-   * Defaults to `exclude` property of tsconfig.json or `'node_module/**'` if not supplied.
+   * Defaults to `exclude` property of tsconfig.json or `'node_modules/**'` if not supplied.
    */
   exclude?: string | string[],
 


### PR DESCRIPTION
Noticed this when copying from doc to use the exclude option.