### PR TITLE
feat: Allow specifying extension of declaration files

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -83,6 +83,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
     copyDtsFiles = false,
     declarationOnly = false,
     strictOutput = true,
+    dtsExtension = '.d.ts',
     afterDiagnostic = noop,
     beforeWriteFile = noop,
     afterBuild = noop
@@ -474,9 +475,6 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
       const emittedFiles = new Map<string, string>()
 
       const writeOutput = async (path: string, content: string, outDir: string, record = true) => {
-        // path = path.replace('.d.ts', '.d.cts')
-        // console.log(path)
-
         if (typeof beforeWriteFile === 'function') {
           const result = await wrapPromise(beforeWriteFile(path, content))
 
@@ -550,6 +548,8 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
           )
           content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
 
+          path = path.replace('.d.ts', dtsExtension)
+
           if (isMapFile) {
             try {
               const sourceMap: { sources: string[] } = JSON.parse(content)
@@ -562,7 +562,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
                   )
                 )
               })
-              content = JSON.stringify(sourceMap)
+              content = JSON.stringify(sourceMap).replace('.d.ts', dtsExtension)
             } catch (e) {
               logger.warn(`${logPrefix} ${yellow('Processing source map fail:')} ${path}`)
             }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -546,7 +546,6 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
             outDir,
             relative(entryRoot, cleanVueFileName ? path.replace('.vue.d.ts', '.d.ts') : path)
           )
-
           content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
 
           if (dtsExtension && !rollupTypes) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -83,7 +83,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
     copyDtsFiles = false,
     declarationOnly = false,
     strictOutput = true,
-    dtsExtension = '.d.ts',
+    dtsExtension,
     afterDiagnostic = noop,
     beforeWriteFile = noop,
     afterBuild = noop
@@ -548,7 +548,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
           )
           content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
 
-          path = path.replace('.d.ts', dtsExtension)
+          path = dtsExtension ? path.replace('.d.ts', dtsExtension) : path
 
           if (isMapFile) {
             try {
@@ -562,7 +562,8 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
                   )
                 )
               })
-              content = JSON.stringify(sourceMap).replace('.d.ts', dtsExtension)
+              content = JSON.stringify(sourceMap)
+              content = dtsExtension ? content.replace('.d.ts', dtsExtension) : content
             } catch (e) {
               logger.warn(`${logPrefix} ${yellow('Processing source map fail:')} ${path}`)
             }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -549,7 +549,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
 
           content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
 
-          if (dtsExtension) {
+          if (dtsExtension && !rollupTypes) {
             path = path.replace('.d.ts', dtsExtension)
             content = content.replaceAll('.d.ts', dtsExtension)
           }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -546,9 +546,13 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
             outDir,
             relative(entryRoot, cleanVueFileName ? path.replace('.vue.d.ts', '.d.ts') : path)
           )
-          path = dtsExtension ? path.replace('.d.ts', dtsExtension) : path
 
           content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
+
+          if (dtsExtension) {
+            path = path.replace('.d.ts', dtsExtension)
+            content = content.replaceAll('.d.ts', dtsExtension)
+          }
 
           if (isMapFile) {
             try {
@@ -563,7 +567,6 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
                 )
               })
               content = JSON.stringify(sourceMap)
-              content = dtsExtension ? content.replace('.d.ts', dtsExtension) : content
             } catch (e) {
               logger.warn(`${logPrefix} ${yellow('Processing source map fail:')} ${path}`)
             }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -474,6 +474,8 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
       const emittedFiles = new Map<string, string>()
 
       const writeOutput = async (path: string, content: string, outDir: string, record = true) => {
+        path = path.replace('.d.ts', '.d.cts')
+        console.log(path)
         if (typeof beforeWriteFile === 'function') {
           const result = await wrapPromise(beforeWriteFile(path, content))
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -474,8 +474,9 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
       const emittedFiles = new Map<string, string>()
 
       const writeOutput = async (path: string, content: string, outDir: string, record = true) => {
-        path = path.replace('.d.ts', '.d.cts')
-        console.log(path)
+        // path = path.replace('.d.ts', '.d.cts')
+        // console.log(path)
+
         if (typeof beforeWriteFile === 'function') {
           const result = await wrapPromise(beforeWriteFile(path, content))
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -546,9 +546,9 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
             outDir,
             relative(entryRoot, cleanVueFileName ? path.replace('.vue.d.ts', '.d.ts') : path)
           )
-          content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
-
           path = dtsExtension ? path.replace('.d.ts', dtsExtension) : path
+
+          content = cleanVueFileName ? content.replace(vuePathRE, '"$1"') : content
 
           if (isMapFile) {
             try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,5 +256,12 @@ export interface PluginOptions {
    *
    * @default () => {}
    */
-  afterBuild?: (emittedFiles: Map<string, string>) => MaybePromise<void>
+  afterBuild?: (emittedFiles: Map<string, string>) => MaybePromise<void>,
+
+  /**
+   * The extension to be used for declaration files
+   *
+   * Can override the default (`.d.ts`) with a custom extension (e.g. `.d.cts`, `.d.mts`)
+   */
+  dtsExtension?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,13 @@ export interface PluginOptions {
   logLevel?: LogLevel,
 
   /**
+   * The extension to be used for declaration files
+   *
+   * Can override the default (`.d.ts`) with a custom extension (e.g. `.d.cts`, `.d.mts`)
+   */
+  dtsExtension?: string,
+
+  /**
    * Hook called after diagnostic is emitted
    *
    * According to the `diagnostics.length`, you can judge whether there is any type error
@@ -256,12 +263,5 @@ export interface PluginOptions {
    *
    * @default () => {}
    */
-  afterBuild?: (emittedFiles: Map<string, string>) => MaybePromise<void>,
-
-  /**
-   * The extension to be used for declaration files
-   *
-   * Can override the default (`.d.ts`) with a custom extension (e.g. `.d.cts`, `.d.mts`)
-   */
-  dtsExtension?: string
+  afterBuild?: (emittedFiles: Map<string, string>) => MaybePromise<void>
 }


### PR DESCRIPTION
Fixes #267

This allows you to replace the `.d.ts` extension with one of your liking (e.g. `.d.cts`, `.d.mts`) by passing in the `dtsExtension` option.

If not set, it does nothing. If set, it changes where declarations and declaration maps get written, updates the `"file"` field in the declaration map, and updates the `sourceMappingURL` field in the declaration.

I found it was incompatible with `rollupTypes: true`, so it will not run if it finds this is enabled. Making that compatible would require a more extensive refactor. 

This solves needing to use an `afterBuild` function to rename file extensions.
