### PR TITLE
plugin: don't panic on missing files

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -695,7 +695,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
             rollupFiles.add(typesPath)
           }
 
-          await runParallel(cpus().length, Array.from(emittedFiles.keys()), f => unlink(f))
+          await runParallel(cpus().length, Array.from(emittedFiles.keys()), f => unlink(f).catch(noop))
           removeDirIfEmpty(outDir)
           emittedFiles.clear()
 


### PR DESCRIPTION
When using the build API from Vite instead of the CLI, intermediate files are not written it seems. The resulting .d.ts file is correct.