### PR TITLE
fix: compatibility with `"moduleResolution": "Node16"`

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -629,7 +629,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
 
           let fromPath = normalizePath(relative(dirname(entryDtsPath), sourceEntry))
 
-          fromPath = fromPath.replace(dtsRE, '')
+          fromPath = fromPath.replace(dtsRE, `.${extPrefix(entryDtsPath)}js`)
           fromPath = fullRelativeRE.test(fromPath) ? fromPath : `./${fromPath}`
 
           let content = `export * from '${fromPath}'\n`


### PR DESCRIPTION
If the project uses `moduleResolution` with the value `Node16` and `rollupTypes` is enabled, then an error occurs:

```
Error: [vite:dts] Internal Error: getResolvedModule() could not resolve module name "./path/to/file"
```

If we do not remove `.ts` completely, but replace it with `.js`, then the problem disappears.