### PR TITLE
fix: update vue-tsc to fix Global types identifiers conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "kolorist": "^1.8.0",
     "local-pkg": "^0.5.0",
     "magic-string": "^0.30.10",
-    "vue-tsc": "2.0.19"
+    "vue-tsc": "^2.0.28"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",


### PR DESCRIPTION
In  vue-tsc:2.0.28 , https://github.com/vuejs/language-tools/commit/f2789d9f845469ac28cdefa562a524dbc89fcb76   , fix the bug:  https://github.com/vuejs/language-tools/issues/4231