### PR TITLE
fix: typescript lib path resolution for api-extractor in monorepo

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   ensureArray,
   findTypesPath,
   getTsConfig,
+  getTsLibFolder,
   isNativeObj,
   isRegExp,
   normalizePath,
@@ -690,18 +691,6 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
         if (rollupTypes) {
           logger.info(green(`${logPrefix} Start rollup declaration files...`))
 
-          let libFolder: string | undefined = resolve(root, 'node_modules/typescript')
-
-          if (!existsSync(libFolder)) {
-            if (root !== entryRoot) {
-              libFolder = resolve(entryRoot, 'node_modules/typescript')
-
-              if (!existsSync(libFolder)) libFolder = undefined
-            }
-
-            libFolder = undefined
-          }
-
           const rollupFiles = new Set<string>()
           const compilerOptions = configPath
             ? getTsConfig(configPath, host.readFile).compilerOptions
@@ -715,7 +704,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
               outDir,
               entryPath: path,
               fileName: basename(path),
-              libFolder,
+              libFolder: getTsLibFolder({ root, entryRoot }),
               rollupConfig,
               rollupOptions
             })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
   sep
 } from 'node:path'
 import { existsSync, lstatSync, readdirSync, rmdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
 
 import ts from 'typescript'
 
@@ -247,6 +248,37 @@ export function getTsConfig(
   return tsConfig
 }
 
+export function getTsLibFolder({
+  root,
+  entryRoot
+}: {
+  root: string,
+  entryRoot: string
+}): string | undefined {
+  let libFolder
+  try {
+    // try the `require.resolve` method first
+    // @see https://stackoverflow.com/questions/54977743/do-require-resolve-for-es-modules
+    libFolder = createRequire(import.meta.url)
+      .resolve('typescript')
+      .replace(/node_modules\/typescript.*/, 'node_modules/typescript')
+  } catch {
+    // fallback to legacy path method
+    libFolder = resolve(root, 'node_modules/typescript')
+
+    if (!existsSync(libFolder)) {
+      if (root !== entryRoot) {
+        libFolder = resolve(entryRoot, 'node_modules/typescript')
+
+        if (!existsSync(libFolder)) libFolder = undefined
+      }
+
+      libFolder = undefined
+    }
+  }
+  return libFolder
+}
+
 /**
  * @see https://github.com/mozilla/source-map/blob/master/lib/base64-vlq.js
  */
@@ -342,7 +374,12 @@ export function findTypesPath(...pkgs: Record<any, any>[]) {
   for (const pkg of pkgs) {
     if (typeof pkg !== 'object') continue
 
-    path = pkg.types || pkg.typings || pkg.exports?.types || pkg.exports?.['.']?.types || pkg.exports?.['./']?.types
+    path =
+      pkg.types ||
+      pkg.typings ||
+      pkg.exports?.types ||
+      pkg.exports?.['.']?.types ||
+      pkg.exports?.['./']?.types
 
     if (path) return path
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,14 +248,9 @@ export function getTsConfig(
   return tsConfig
 }
 
-export function getTsLibFolder({
-  root,
-  entryRoot
-}: {
-  root: string,
-  entryRoot: string
-}): string | undefined {
-  let libFolder
+export function getTsLibFolder({ root, entryRoot }: { root: string, entryRoot: string }) {
+  let libFolder: string | undefined
+
   try {
     // try the `require.resolve` method first
     // @see https://stackoverflow.com/questions/54977743/do-require-resolve-for-es-modules
@@ -276,6 +271,7 @@ export function getTsLibFolder({
       libFolder = undefined
     }
   }
+
   return libFolder
 }
 


### PR DESCRIPTION
该 PR 修复 Monorepo 项目中 vite-plugin-dts 对 TypeScript 依赖库路径获取的问题。

## 问题描述

Monorepo 项目的 Workspace Root 安装 TS 版本为 `v5.5.4`，在子项目中 vite-plugin-dts 没有正确获取 Workspace Root 的 TS（通过 debug 观察 libFolder 变量值为 `undefined`），而它使用了 `api-extractor` 内置的 TS `v5.4.2` 版本，如图：

<img width="1265" alt="SCR-20240802-mhnz" src="https://github.com/user-attachments/assets/fab3fd7c-d999-46f9-a218-d0f620fb8004">

<img width="816" alt="SCR-20240802-miud" src="https://github.com/user-attachments/assets/8d37d39c-741e-440d-aed2-23e200250f8f">

可能相关的 ISSUE：https://github.com/qmhc/vite-plugin-dts/issues/266

## 问题触发条件

Monorepo 项目，如果 `<WorkspaceRoot>/node_modules/typescript` 存在，但子项目 `<WorkspaceRoot>/packages/xxx/node_modules/typescript` 不存在。

## 复现步骤

1. 创建 Monorepo 并初始化 Node 子项目
2. 在 Workspace Root 安装 typescript v5.5.4 (`pnpm add -D --workspace-root typescript`)
3. 执行子项目的编译（`pnpm -F vite-project build`）

## 复现代码

https://github.com/qwqcode/vite-plugin-dts-mre

clone 后给 node_modules 中的相关代码打上断点，通过 VSCode JS 调试终端执行 `pnpm build`

## 旧版实现

生成 dts 文件调用 `@microsoft/api-extractor` 的 `Extractor.invoke` 方法会传递 [typescriptCompilerFolder](https://api.rushstack.io/pages/api-extractor.icompilerstatecreateoptions.typescriptcompilerfolder/) 参数，指定 TypeScript 库的路径：

https://github.com/qmhc/vite-plugin-dts/blob/f5d9c06f1461ca1e1b8e901ffb23fe0731e00e09/src/rollup.ts#L92

为了让 `api-extractor` 工具中调用的 TS 和用户开发环境的 TS 版本一致，需正确设置 typescriptCompilerFolder 参数。

如果为 `undefined` 则会默认使用 `api-extractor` 自带的 TS，与开发环境 TS 版本可能不符，从而导致问题。目前旧版在 Monorepo 项目下  `libFolder` 变量可能为 `undefined`。

TS 库路径变量 `libFolder` 是通过字符串拼接得到的：

https://github.com/qmhc/vite-plugin-dts/blob/f5d9c06f1461ca1e1b8e901ffb23fe0731e00e09/src/plugin.ts#L657-L670

## 新版实现

修改为通过调用 Node 的 API `require.resolve('typescript')`  获取编译时用户当前项目中安装的 TS 路径。

兼容性方面，为了同时兼容 ES Modules 和 CommonJS，使用 `createRequire(import.meta.url)` 获取 require 对象并调用 resolve 方法 [^1]。

为了保险起见，仍然通过 try catch 提供了 fallback 的解决方案，保留旧版的字符串拼接代码。

性能方面，`libFolder` 通过 `require.resolve` 只需在编译过程中获取一次。

已测试 TS 路径在 Monorepo 项目中也能正确获取：

![SCR-20240802-mwih](https://github.com/user-attachments/assets/d4c888da-601b-48c4-a0be-2c682fe6b39f)

---

其他可能的改进：通过更新日志发现 [3.0.0-beta.2](https://github.com/qmhc/vite-plugin-dts/compare/v2.3.0...v3.0.0-beta.2) 版本将 `libFolderPath` 参数移除，目前 `rollupTypes` 功能不支持自定义 TS 库路径，可以考虑增加一个参数。

[^1]: 参考：https://stackoverflow.com/questions/54977743/do-require-resolve-for-es-modules