### PR TITLE
fix: normalize typescript lib path for rollup

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -254,9 +254,10 @@ export function getTsLibFolder({ root, entryRoot }: { root: string, entryRoot: s
   try {
     // try the `require.resolve` method first
     // @see https://stackoverflow.com/questions/54977743/do-require-resolve-for-es-modules
-    libFolder = createRequire(import.meta.url)
-      .resolve('typescript')
-      .replace(/node_modules\/typescript.*/, 'node_modules/typescript')
+    libFolder = normalizePath(createRequire(import.meta.url).resolve('typescript')).replace(
+      /node_modules\/typescript.*/,
+      'node_modules/typescript'
+    )
   } catch {
     // fallback to legacy path method
     libFolder = resolve(root, 'node_modules/typescript')

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -2,6 +2,7 @@
 /* eslint-disable promise/param-names */
 
 import { normalize, resolve } from 'node:path'
+import { existsSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -175,12 +176,16 @@ describe('utils tests', () => {
 
   it('test: getTsLibFolder', () => {
     const root = normalizePath(resolve(__dirname, '..'))
+    const entryRoot = resolve(root, 'src')
 
     expect(
-      getTsLibFolder({
-        root: root,
-        entryRoot: resolve(root, 'src')
-      })
+      getTsLibFolder({ root, entryRoot })
     ).toMatch(/node_modules\/typescript$/)
+
+    expect(
+      existsSync(
+        getTsLibFolder({ root, entryRoot }) || ''
+      )
+    ).toBe(true)
   })
 })

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   base64VLQEncode,
   ensureAbsolute,
   ensureArray,
+  getTsLibFolder,
   isNativeObj,
   isPromise,
   isRegExp,
@@ -170,5 +171,16 @@ describe('utils tests', () => {
     expect(toCapitalCase(' aa bb cc ')).toEqual('AaBbCc')
     expect(toCapitalCase('-aa bb cc ')).toEqual('AaBbCc')
     expect(toCapitalCase(' -aa bb cc -')).toEqual('AaBbCc')
+  })
+
+  it('test: getTsLibFolder', () => {
+    const root = normalizePath(resolve(__dirname, '..'))
+
+    expect(
+      getTsLibFolder({
+        root: root,
+        entryRoot: resolve(root, 'src')
+      })
+    ).toMatch(/node_modules\/typescript$/)
   })
 })


### PR DESCRIPTION
本 PR 补充修复 #360 中新增的 `getTsLibFolder` 函数在 Win 环境下出现不符合预期的问题。

**预期结果** (末尾不包含 `/lib/typescript.js`)：

```
'node_modules/.pnpm/typescript@5.5.4/node_modules/typescript'
```

**错误结果**：

```
'node_modules/.pnpm/typescript@5.5.4/node_modules/typescript/lib/typescript.js'
```

在 Windows 环境下，由于路径分隔符斜杠和 Unix 环境不同，`require.resolve('typescript')` 返回结果需要做 `normalizePath` 处理，这样才能始终正确地 replace 去掉末尾的 `/lib/typescript.js`。

https://github.com/qmhc/vite-plugin-dts/pull/360#issuecomment-2277836720