### PR TITLE
Fix issue with nested imports

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -442,7 +442,7 @@ export function parseTsAliases(basePath: string, paths: ts.MapLike<string[]>) {
 
   for (const [pathWithAsterisk, replacements] of Object.entries(paths)) {
     const find = new RegExp(
-      `^${pathWithAsterisk.replace(regexpSymbolRE, '\\$1').replace(asteriskRE, '([^\\/]+)')}$`
+      `^${pathWithAsterisk.replace(regexpSymbolRE, '\\$1').replace(asteriskRE, '(.+)')}$`
     )
 
     let index = 1

--- a/tests/transform.spec.ts
+++ b/tests/transform.spec.ts
@@ -167,6 +167,12 @@ describe('transform tests', () => {
         filePath: './src/child/folder/test.ts',
         content: 'import { utilFunction } from "@/utils/test";',
         output: "import { utilFunction } from '../../../utils/test';\n"
+      },
+      {
+        description: 'alias as everything, relative import',
+        aliases: [{ find: /^(.+)$/, replacement: resolve(__dirname, '../src/$1') }],
+        content: 'import { TestBase } from "test";',
+        output: "import { TestBase } from './test';\n"
       }
     ]
 
@@ -203,6 +209,10 @@ describe('transform tests', () => {
 
     expect(transformCode(options('import { TestNested } from "@/nested/test";')).content).toEqual(
       "import { TestNested } from './nested/test';\n"
+    )
+
+    expect(transformCode(options('import { TestBase } from "./test";')).content).toEqual(
+      "import { TestBase } from './utils/test';\n"
     )
   })
 

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -159,6 +159,9 @@ describe('utils tests', () => {
   })
 
   it('test: parseTsAliases', () => {
+    const maybeWindowsPath = (path: string) =>
+      new RegExp('^([a-zA-Z]:)?' + path.replace('$', '\\$'))
+
     expect(
       parseTsAliases('/tmp/fake/project/root', {
         '@/*': ['./at/*']
@@ -166,14 +169,14 @@ describe('utils tests', () => {
     ).toStrictEqual([
       {
         find: /^@\/(.+)$/,
-        replacement: '/tmp/fake/project/root/at/$1'
+        replacement: expect.stringMatching(maybeWindowsPath('/tmp/fake/project/root/at/$1'))
       }
     ])
 
     expect(parseTsAliases('/tmp/fake/project/root', { '~/*': ['./tilde/*'] })).toStrictEqual([
       {
         find: /^~\/(.+)$/,
-        replacement: '/tmp/fake/project/root/tilde/$1'
+        replacement: expect.stringMatching(maybeWindowsPath('/tmp/fake/project/root/tilde/$1'))
       }
     ])
 
@@ -182,7 +185,9 @@ describe('utils tests', () => {
     ).toStrictEqual([
       {
         find: /^@\/no-dot-prefix\/(.+)$/,
-        replacement: '/tmp/fake/project/root/no-dot-prefix/$1'
+        replacement: expect.stringMatching(
+          maybeWindowsPath('/tmp/fake/project/root/no-dot-prefix/$1')
+        )
       }
     ])
 
@@ -191,21 +196,23 @@ describe('utils tests', () => {
     ).toStrictEqual([
       {
         find: /^@\/components\/(.+)$/,
-        replacement: '/tmp/fake/project/root/at/components/$1'
+        replacement: expect.stringMatching(
+          maybeWindowsPath('/tmp/fake/project/root/at/components/$1')
+        )
       }
     ])
 
     expect(parseTsAliases('/tmp/fake/project/root', { 'top/*': ['./top/*'] })).toStrictEqual([
       {
         find: /^top\/(.+)$/,
-        replacement: '/tmp/fake/project/root/top/$1'
+        replacement: expect.stringMatching(maybeWindowsPath('/tmp/fake/project/root/top/$1'))
       }
     ])
 
     expect(parseTsAliases('/tmp/fake/project/root', { '@src': ['./src'] })).toStrictEqual([
       {
         find: /^@src$/,
-        replacement: '/tmp/fake/project/root/src'
+        replacement: expect.stringMatching(maybeWindowsPath('/tmp/fake/project/root/src'))
       }
     ])
 
@@ -213,7 +220,7 @@ describe('utils tests', () => {
     expect(parseTsAliases('/tmp/fake/project/root', { '*': ['./src/*'] })).toStrictEqual([
       {
         find: /^(.+)$/,
-        replacement: '/tmp/fake/project/root/src/$1'
+        replacement: expect.stringMatching(maybeWindowsPath('/tmp/fake/project/root/src/$1'))
       }
     ])
 
@@ -221,7 +228,7 @@ describe('utils tests', () => {
     expect(parseTsAliases('/tmp/fake/project/root', { '#*': ['./hashed/*'] })).toStrictEqual([
       {
         find: /^#(.+)$/,
-        replacement: '/tmp/fake/project/root/hashed/$1'
+        replacement: expect.stringMatching(maybeWindowsPath('/tmp/fake/project/root/hashed/$1'))
       }
     ])
   })

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable prefer-regex-literals */
-/* eslint-disable promise/param-names */
-
 import { normalize, resolve } from 'node:path'
 import { existsSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
@@ -15,6 +12,7 @@ import {
   isRegExp,
   mergeObjects,
   normalizePath,
+  parseTsAliases,
   queryPublicPath,
   toCapitalCase,
   unwrapPromise
@@ -160,6 +158,74 @@ describe('utils tests', () => {
     }
   })
 
+  it('test: parseTsAliases', () => {
+    expect(
+      parseTsAliases('/tmp/fake/project/root', {
+        '@/*': ['./at/*']
+      })
+    ).toStrictEqual([
+      {
+        find: /^@\/(.+)$/,
+        replacement: '/tmp/fake/project/root/at/$1'
+      }
+    ])
+
+    expect(parseTsAliases('/tmp/fake/project/root', { '~/*': ['./tilde/*'] })).toStrictEqual([
+      {
+        find: /^~\/(.+)$/,
+        replacement: '/tmp/fake/project/root/tilde/$1'
+      }
+    ])
+
+    expect(
+      parseTsAliases('/tmp/fake/project/root', { '@/no-dot-prefix/*': ['no-dot-prefix/*'] })
+    ).toStrictEqual([
+      {
+        find: /^@\/no-dot-prefix\/(.+)$/,
+        replacement: '/tmp/fake/project/root/no-dot-prefix/$1'
+      }
+    ])
+
+    expect(
+      parseTsAliases('/tmp/fake/project/root', { '@/components/*': ['./at/components/*'] })
+    ).toStrictEqual([
+      {
+        find: /^@\/components\/(.+)$/,
+        replacement: '/tmp/fake/project/root/at/components/$1'
+      }
+    ])
+
+    expect(parseTsAliases('/tmp/fake/project/root', { 'top/*': ['./top/*'] })).toStrictEqual([
+      {
+        find: /^top\/(.+)$/,
+        replacement: '/tmp/fake/project/root/top/$1'
+      }
+    ])
+
+    expect(parseTsAliases('/tmp/fake/project/root', { '@src': ['./src'] })).toStrictEqual([
+      {
+        find: /^@src$/,
+        replacement: '/tmp/fake/project/root/src'
+      }
+    ])
+
+    // https://github.com/qmhc/vite-plugin-dts/issues/330
+    expect(parseTsAliases('/tmp/fake/project/root', { '*': ['./src/*'] })).toStrictEqual([
+      {
+        find: /^(.+)$/,
+        replacement: '/tmp/fake/project/root/src/$1'
+      }
+    ])
+
+    // https://github.com/qmhc/vite-plugin-dts/issues/290#issuecomment-1872495764
+    expect(parseTsAliases('/tmp/fake/project/root', { '#*': ['./hashed/*'] })).toStrictEqual([
+      {
+        find: /^#(.+)$/,
+        replacement: '/tmp/fake/project/root/hashed/$1'
+      }
+    ])
+  })
+
   it('test: toCapitalCase', () => {
     expect(toCapitalCase('abc')).toEqual('Abc')
     expect(toCapitalCase('aa-bb-cc')).toEqual('AaBbCc')
@@ -178,14 +244,8 @@ describe('utils tests', () => {
     const root = normalizePath(resolve(__dirname, '..'))
     const entryRoot = resolve(root, 'src')
 
-    expect(
-      getTsLibFolder({ root, entryRoot })
-    ).toMatch(/node_modules\/typescript$/)
+    expect(getTsLibFolder({ root, entryRoot })).toMatch(/node_modules\/typescript$/)
 
-    expect(
-      existsSync(
-        getTsLibFolder({ root, entryRoot }) || ''
-      )
-    ).toBe(true)
+    expect(existsSync(getTsLibFolder({ root, entryRoot }) || '')).toBe(true)
   })
 })


### PR DESCRIPTION
### Context

With a path alias like `@/*` pointing to `src/*`, an import like this:

an import statement like `import { foo } from '@/foo'`
transforms to `import { foo } from './src/foo'`

### Problem

There is an issue, however, with nested imports being ignored:

an import like `import { foo } from '@/nested/foo'`
should transformed to `import { foo } from './src/nested/foo'`
but actually just stays as `import { foo } from '@/nested/foo'`

### Solution
The fix was to update the regex pattern to look for *anything* in place of the asterisk (`(.+)`) rather than just 'any non forward slash' (`([^\\/]+)`).
https://github.com/qmhc/vite-plugin-dts/blob/8a0c1406a97e217c1ccdfc0addf69351294eb934/src/utils.ts#L444-L446

#### Details
The commit log tells the story best and that's probably the easiest way to review the PR as well:
- **test(transform): add failing integration test for transformCode**
  This test covers the issue. 

- **fix(utils): correct issue with failing integration test**
   This is the fix mentioned above.

- **test(utils): add tests for parseTsAliases**
  This test just covers the new regex pattern and a couple of extra cases I found from some recent open issues.

- **test(transform): refactor process aliases test with helper and descriptions, add more cases**
  This wasn't strictly necessary, but I wanted to make the test more readable and add a few more cases.

- **test: adds test cases from issue and fixes #330**
   This is an additional test case to cover the issues mentioned in #330