### PR TITLE
fix: set baseUrl if none is provided

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -288,7 +288,13 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
           : [ensureAbsolute(content?.raw.compilerOptions?.outDir || 'dist', root)]
       }
 
-      const { baseUrl, paths } = compilerOptions
+      const {
+        // Here we are using the default value to set the `baseUrl` to the current directory if no value exists. This is
+        // the same behavior as the TS Compiler. See TS source:
+        // https://github.com/microsoft/TypeScript/blob/3386e943215613c40f68ba0b108cda1ddb7faee1/src/compiler/utilities.ts#L6493-L6501
+        baseUrl = compilerOptions.paths ? process.cwd() : undefined,
+        paths
+      } = compilerOptions
 
       if (pathsToAliases && baseUrl && paths) {
         aliases.push(


### PR DESCRIPTION
If `paths` is set in TS compilerOptions, then as of TS4.1, the TS compiler will ensure that the `baseUrl` is set to the current working directory.

- [Relevant TS Source](https://github.com/microsoft/TypeScript/blob/3386e943215613c40f68ba0b108cda1ddb7faee1/src/compiler/utilities.ts#L6493-L6501)
- [TS 4.1 Release (`paths` without `baseUrl`)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#paths-without-baseurl)

This PR aligns the plugin to the compiler behavior.