### PR TITLE
fix: use entry name instead of entry path to generate indexName

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -201,7 +201,7 @@ export function dtsPlugin(options: PluginOptions = {}): import('vite').Plugin {
         const entry =
           typeof config.build.lib.entry === 'string'
             ? config.build.lib.entry
-            : Object.values(config.build.lib.entry)[0]
+            : Object.keys(config.build.lib.entry)[0]
 
         libName = config.build.lib.name || '_default'
         indexName = typeof filename === 'string' ? filename : filename('es', entry)


### PR DESCRIPTION
vite use format and entry to generate fileName
keep the same with vite