### PR TITLE
fix: correct package.json exports field to fix FalseESM issue

### DIFF
--- a/packages/unplugin-dts/package.json
+++ b/packages/unplugin-dts/package.json
@@ -16,39 +16,74 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "default": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./esbuild": {
-      "types": "./dist/esbuild.d.ts",
-      "import": "./dist/rolldown.mjs",
-      "require": "./dist/esbuild.cjs"
+      "import": {
+        "types": "./dist/esbuild.d.mts",
+        "default": "./dist/esbuild.mjs"
+      },
+      "default": {
+        "types": "./dist/esbuild.d.cts",
+        "default": "./dist/esbuild.cjs"
+      }
     },
     "./rolldown": {
-      "types": "./dist/rolldown.d.ts",
-      "import": "./dist/rolldown.mjs",
-      "require": "./dist/rolldown.cjs"
+      "import": {
+        "types": "./dist/rolldown.d.mts",
+        "default": "./dist/rolldown.mjs"
+      },
+      "default": {
+        "types": "./dist/rolldown.d.cts",
+        "default": "./dist/rolldown.cjs"
+      }
     },
     "./rollup": {
-      "types": "./dist/rollup.d.ts",
-      "import": "./dist/rollup.mjs",
-      "require": "./dist/rollup.cjs"
+      "import": {
+        "types": "./dist/rollup.d.mts",
+        "default": "./dist/rollup.mjs"
+      },
+      "default": {
+        "types": "./dist/rollup.d.cts",
+        "default": "./dist/rollup.cjs"
+      }
     },
     "./rspack": {
-      "types": "./dist/rspack.d.ts",
-      "import": "./dist/rspack.mjs",
-      "require": "./dist/rspack.cjs"
+      "import": {
+        "types": "./dist/rspack.d.mts",
+        "default": "./dist/rspack.mjs"
+      },
+      "default": {
+        "types": "./dist/rspack.d.cts",
+        "default": "./dist/rspack.cjs"
+      }
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
-      "import": "./dist/vite.mjs",
-      "require": "./dist/vite.cjs"
+      "import": {
+        "types": "./dist/vite.d.mts",
+        "default": "./dist/vite.mjs"
+      },
+      "default": {
+        "types": "./dist/vite.d.cts",
+        "default": "./dist/vite.cjs"
+      }
     },
     "./webpack": {
-      "types": "./dist/webpack.d.ts",
-      "import": "./dist/webpack.mjs",
-      "require": "./dist/webpack.cjs"
+      "import": {
+        "types": "./dist/webpack.d.mts",
+        "default": "./dist/webpack.mjs"
+      },
+      "default": {
+        "types": "./dist/webpack.d.cts",
+        "default": "./dist/webpack.cjs"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -94,6 +129,9 @@
     "magic-string": "^0.30.17",
     "unplugin": "^2.3.2"
   },
+  "devDependencies": {
+    "@microsoft/api-extractor": "^7.52.5"
+  },
   "peerDependencies": {
     "@microsoft/api-extractor": ">=7",
     "@rspack/core": "^1",
@@ -103,9 +141,6 @@
     "typescript": ">=4",
     "vite": ">=3",
     "webpack": "^4 || ^5"
-  },
-  "devDependencies": {
-    "@microsoft/api-extractor": "^7.52.5"
   },
   "peerDependenciesMeta": {
     "@microsoft/api-extractor": {

--- a/packages/vite-plugin-dts/package.json
+++ b/packages/vite-plugin-dts/package.json
@@ -13,9 +13,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "default": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -47,13 +52,13 @@
   "dependencies": {
     "unplugin-dts": "workspace:*"
   },
+  "devDependencies": {
+    "@microsoft/api-extractor": "^7.52.5"
+  },
   "peerDependencies": {
     "@microsoft/api-extractor": ">=7",
     "rollup": ">=3",
     "vite": ">=3"
-  },
-  "devDependencies": {
-    "@microsoft/api-extractor": "^7.52.5"
   },
   "peerDependenciesMeta": {
     "@microsoft/api-extractor": {


### PR DESCRIPTION
The package `unplugin-dts@1.0.0-beta.0` has [`FalseESM`](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md) issue. This PR fixes the issue.

Check result: [arethetypeswrong.github.io](https://arethetypeswrong.github.io/?p=unplugin-dts%401.0.0-beta.0)

Related discussions: https://github.com/qmhc/vite-plugin-dts/issues/267