### PR TITLE
fix: normalize typesPath to make rollupFiles and emittedFiles consistent

### DIFF
--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -607,6 +607,7 @@ export class Runtime {
         types ? resolve(root, types) : resolve(outDir, indexName),
         emittedFiles,
       )
+      typesPath = normalizePath(typesPath)
   
       if (!multiple && !dtsRE.test(typesPath)) {
         logger.warn(


### PR DESCRIPTION
Normalize typesPath to make rollupFiles and emittedFiles consistent, otherwise rollupFiles will be mistakenly unlink at line 694.