### PR TITLE
fix: add npm overrides and yarn resolutions for minimatch ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
     "vitest": "^3.1.2",
     "webpack": "^5.100.2"
   },
+  "overrides": {
+    "@microsoft/api-extractor": "^7.57.6",
+    "minimatch": "^10.2.4"
+  },
+  "resolutions": {
+    "@microsoft/api-extractor": "^7.57.6",
+    "minimatch": "^10.2.4"
+  },
   "pnpm": {
     "overrides": {
       "@microsoft/api-extractor@<7.57.6": "7.57.6",


### PR DESCRIPTION
### Description
Currently, the `package.json` protects `pnpm` users from the high-severity `minimatch` ReDoS vulnerability (via `@microsoft/api-extractor`) using the `pnpm.overrides` field. 

However, users of `npm` and `yarn` are not protected by this field and are inadvertently downloading the vulnerable `minimatch@10.2.1` version. 

This PR simply replicates the existing `pnpm.overrides` logic into the standard `"overrides"` (for npm) and `"resolutions"` (for yarn) fields so that all package managers correctly resolve to the patched `minimatch@10.2.4` version.

### Fixes
- Protects `npm` and `yarn` users from: https://github.com/advisories/GHSA-7r86-cg39-jmmj