### PR TITLE
fix: publicRoot mismtach of TS 6.0 rootDir

### DIFF
--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -5,6 +5,7 @@ import { cpus } from 'node:os'
 
 import ts from 'typescript'
 import { createFilter } from '@rollup/pluginutils'
+import { compare } from 'compare-versions'
 import { green, red, yellow } from 'kolorist'
 import { loadProgramProcessor } from './processor'
 import { JsonResolver, SvelteResolver, VueResolver, parseResolvers } from './resolvers'
@@ -274,12 +275,14 @@ export class Runtime {
       ? ensureAbsolute(resolveConfigDir(compilerOptions.rootDir, root), root)
       : compilerOptions.composite && compilerOptions.configFilePath
         ? dirname(compilerOptions.configFilePath as string)
-        : queryPublicPath(
-          program
-            .getSourceFiles()
-            .filter(maybeEmitted)
-            .map(sourceFile => sourceFile.fileName),
-        )
+        : compare(ts.version, '6.0.0', '>=')
+          ? root
+          : queryPublicPath(
+            program
+              .getSourceFiles()
+              .filter(maybeEmitted)
+              .map(sourceFile => sourceFile.fileName),
+          )
     publicRoot = normalizePath(publicRoot)
 
     let entryRoot = options.entryRoot || publicRoot

--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -276,7 +276,9 @@ export class Runtime {
       : compilerOptions.composite && compilerOptions.configFilePath
         ? dirname(compilerOptions.configFilePath as string)
         : compare(ts.version, '6.0.0', '>=')
-          ? root
+          ? configPath
+            ? dirname(configPath)
+            : root
           : queryPublicPath(
             program
               .getSourceFiles()


### PR DESCRIPTION
Fixes #467 .

TypeScript 6.0 [changes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#rootdir-now-defaults-to-) the default `rootDir` settings from the public ancestor of source files to the directory of `tsconfig.json`. This causes the default value of `unplugin-dts`'s `publicRoot` mismatched to the resolution after an internal TS compilation callback of file paths. If user do not specify `publicRoot` from `dts` plugin options, when bundling types, the built `.d.ts` cannot add any `import` from the built entry which results in an empty module due to this mismatch.

This PR fix the behavior and now `bundleType` should works under TypeScript 6.0.