### PR TITLE
docs: fix PluginOptions outDir -> outDirs in options.md

### DIFF
--- a/docs/en/options.md
+++ b/docs/en/options.md
@@ -83,12 +83,12 @@ export interface PluginOptions {
    * The default is to use the out directory provided by the scaffold.
    *
    * @example
-   * outDir: 'dist'
-   * outDir: ['dist', 'types']
-   * outDir: { dir: 'dist', moduleFormat: 'esm' }
-   * outDir: ['dist', { dir: 'dist-cjs', moduleFormat: 'cjs' }]
+   * outDirs: 'dist'
+   * outDirs: ['dist', 'types']
+   * outDirs: { dir: 'dist', moduleFormat: 'esm' }
+   * outDirs: ['dist', { dir: 'dist-cjs', moduleFormat: 'cjs' }]
    */
-  outDir?: OutDirsOption,
+  outDirs?: OutDirsOption,
 
   /**
    * Override root path of entry files (useful in monorepos).

--- a/docs/zh/options.md
+++ b/docs/zh/options.md
@@ -83,12 +83,12 @@ export interface PluginOptions {
    * 默认使用脚手架提供的输出目录
    *
    * @example
-   * outDir: 'dist'
-   * outDir: ['dist', 'types']
-   * outDir: { dir: 'dist', moduleFormat: 'esm' }
-   * outDir: ['dist', { dir: 'dist-cjs', moduleFormat: 'cjs' }]
+   * outDirs: 'dist'
+   * outDirs: ['dist', 'types']
+   * outDirs: { dir: 'dist', moduleFormat: 'esm' }
+   * outDirs: ['dist', { dir: 'dist-cjs', moduleFormat: 'cjs' }]
    */
-  outDir?: OutDirsOption,
+  outDirs?: OutDirsOption,
 
   /**
    * 用于手动设置入口文件的根路径（通常用在 monorepo）


### PR DESCRIPTION
## 概要

`docs/en/options.md` および `docs/zh/options.md` の `PluginOptions` プロパティ名と `@example` ブロックが、ランタイム実装(`CreateRuntimeOptions.outDirs?: OutDirsOption`)と一致せず `outDir`(単数)になっていた typo を修正します。

- ドキュメント上は `outDir?: OutDirsOption,` と表記
- 実装は `outDirs?: OutDirsOption,`(`packages/unplugin-dts/src/core/types.ts`)

ドキュメントに従って `outDir: 'dist'` と書いたユーザーは静かにオプションが無視されるため、ユーザーから「outDir が効かなくて時間を溶かした」というコメントが #460 に寄せられています。

Closes #460

## 動作確認

- 変更は **ドキュメントのみ**(`docs/en/options.md` / `docs/zh/options.md`)、コード・ランタイムには無変更
- `packages/unplugin-dts/src/core/types.ts` 内の `CreateRuntimeOptions` を確認、`outDirs?: OutDirsOption` であることを再確認
- `OutDirsOption` 型 (`string | OutDirConfig | (string | OutDirConfig)[]`) はそのまま
- 修正は以下 10 箇所(en/zh それぞれ 5 行):
  - `PluginOptions` プロパティ名(line 91)
  - 直前の `@example` 4 行(line 86-89)
- `AGENTS.md` の「修改公开选项时，同步: types.ts / docs/en/options.md / docs/zh/options.md」に従い、types.ts は既に正しいため docs のみを同期
- gitleaks v8.30.1 で secret スキャン clean

`Resolver.transform` コールバックが受け取る `outDir: string`(単一出力ごと、line 50)などの記述は意図的な単数形のためそのまま残しています。