### PR TITLE
fix: loop through all aliases so wildcard * does not block @/* resolution

### DIFF
--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -5,7 +5,6 @@ import { cpus } from 'node:os'
 
 import ts from './ts-loader.cjs'
 import { createFilter } from '@rollup/pluginutils'
-import { compare } from 'compare-versions'
 import { green, red, yellow } from 'kolorist'
 import { loadProgramProcessor } from './processor'
 import { JsonResolver, SvelteResolver, VueResolver, parseResolvers } from './resolvers'
@@ -276,16 +275,12 @@ export class Runtime {
       ? ensureAbsolute(resolveConfigDir(compilerOptions.rootDir, root), root)
       : compilerOptions.composite && compilerOptions.configFilePath
         ? dirname(compilerOptions.configFilePath as string)
-        : compare(ts.version, '6.0.0', '>=')
-          ? configPath
-            ? dirname(configPath)
-            : root
-          : queryPublicPath(
-            program
-              .getSourceFiles()
-              .filter(maybeEmitted)
-              .map(sourceFile => sourceFile.fileName),
-          )
+        : queryPublicPath(
+          program
+            .getSourceFiles()
+            .filter(maybeEmitted)
+            .map(sourceFile => sourceFile.fileName),
+        ) || (configPath ? dirname(configPath) : root)
     publicRoot = normalizePath(publicRoot)
 
     let entryRoot = options.entryRoot || publicRoot

--- a/packages/unplugin-dts/src/core/transform.ts
+++ b/packages/unplugin-dts/src/core/transform.ts
@@ -56,28 +56,26 @@ function transformAlias(
     aliases?.length &&
     !aliasesExclude.some(e => (isRegExp(e) ? e.test(importer) : String(e) === importer))
   ) {
-    const matchedAlias = aliases.find(alias => isAliasMatch(alias, importer))
+    for (const alias of aliases) {
+      if (!isAliasMatch(alias, importer)) continue
 
-    if (matchedAlias) {
-      const replacement = isAbsolute(matchedAlias.replacement)
-        ? normalizePath(relative(dir, matchedAlias.replacement))
-        : normalizePath(matchedAlias.replacement)
+      const replacement = isAbsolute(alias.replacement)
+        ? normalizePath(relative(dir, alias.replacement))
+        : normalizePath(alias.replacement)
 
       const endsWithSlash =
-        typeof matchedAlias.find === 'string'
-          ? matchedAlias.find.endsWith('/')
-          : importer.match(matchedAlias.find)![0].endsWith('/')
-      const truthPath = importer.replace(
-        matchedAlias.find,
-        replacement + (endsWithSlash ? '/' : ''),
-      )
+        typeof alias.find === 'string'
+          ? alias.find.endsWith('/')
+          : importer.match(alias.find)![0].endsWith('/')
+      const truthPath = importer.replace(alias.find, replacement + (endsWithSlash ? '/' : ''))
 
       const absolutePath = resolve(dir, truthPath)
       const normalizedPath = normalizePath(relative(dir, absolutePath))
       const resultPath = normalizedPath.startsWith('.') ? normalizedPath : `./${normalizedPath}`
 
-      if (!isAliasGlobal(matchedAlias)) return resultPath
+      if (!isAliasGlobal(alias)) return resultPath
       if (importResolves(absolutePath)) return resultPath
+      // global alias didn't resolve — continue to try next alias
     }
   }
 

--- a/packages/unplugin-dts/tests/runtime.spec.ts
+++ b/packages/unplugin-dts/tests/runtime.spec.ts
@@ -48,6 +48,40 @@ describe('runtime tests', () => {
     expect(normalizePath(alias!.replacement)).toBe(normalizePath(resolve(tempDir, 'src/$1')))
   })
 
+  it('should resolve @/* alias when wildcard * path is also present', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '*': ['./src/*'],
+            '@/*': ['./src/*'],
+          },
+        },
+        include: ['src/**/*'],
+      }),
+    )
+
+    mkdirSync(resolve(tempDir, 'src'))
+    writeFileSync(resolve(tempDir, 'src', 'index.ts'), 'export const foo = 1\n')
+    writeFileSync(resolve(tempDir, 'src', 'helper.ts'), 'export const bar = 2\n')
+
+    const runtime = await Runtime.toInstance({
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      pathsToAliases: true,
+    })
+
+    const atAlias = (runtime as any).aliases.find((a: any) =>
+      typeof a.find === 'string' ? a.find === '@/' : a.find.test('@/helper'),
+    )
+
+    expect(atAlias).toBeDefined()
+    expect(normalizePath(atAlias!.replacement)).toBe(normalizePath(resolve(tempDir, 'src/$1')))
+  })
+
   it('should include .vue files when using glob patterns with processor vue', async () => {
     tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
 

--- a/packages/unplugin-dts/tests/transform.spec.ts
+++ b/packages/unplugin-dts/tests/transform.spec.ts
@@ -283,6 +283,33 @@ describe('transform tests', () => {
     ).toEqual("import { someFutureImport } from 'installedDependency';\n")
   })
 
+  it('test: transformCode — wildcard * before @/* does not block @/ resolution', () => {
+    const tsPaths = {
+      '*': ['tests/__fixtures__/*'],
+      '@/*': ['src/*'],
+    }
+
+    const aliases = parseTsAliases(resolve(__dirname, '..'), tsPaths)
+
+    const options = (content: string) => ({
+      content,
+      filePath: resolve(__dirname, '../src/index.ts'),
+      aliases,
+      aliasesExclude: [],
+      staticImport: true,
+      clearPureImport: true,
+      cleanVueFileName: true,
+    })
+
+    expect(transformCode(options('import { Foo } from "@/foo";')).content).toEqual(
+      "import { Foo } from './foo';\n",
+    )
+
+    expect(transformCode(options('import { Foo } from "@/nested/foo";')).content).toEqual(
+      "import { Foo } from './nested/foo';\n",
+    )
+  })
+
   it('test: transformCode (remove pure imports)', () => {
     const options = (content: string) => ({
       content,


### PR DESCRIPTION
## Problem

When `tsconfig.json` paths contains both `"*"` and `"@/*"` (a common pattern in shared tsconfig setups using `${configDir}`), `parseTsAliases` inserts the `"*"` alias first due to object-key insertion order. The previous `aliases.find()` call stopped at the first match, so an import like `@/foo` would hit the global `"*"` alias, fail `importResolves` (because `src/@/foo.ts` doesn't exist), and return the import unchanged — the `"@/*"` alias was never tried.

Fixes https://github.com/qmhc/unplugin-dts/issues/458

## Changes

- **`transform.ts`**: `transformAlias` now iterates all aliases in order. Global aliases that fail `importResolves` continue to the next alias rather than returning early.
- **`runtime.ts`**: Removed the TypeScript >=6.0 special-case that used `dirname(configPath)` for `publicRoot` instead of `queryPublicPath`. This caused output to land in `dist/src/` instead of `dist/`. `queryPublicPath` now always runs, with `dirname(configPath)` as fallback only when no source files are found.
- **Tests**: Added cases for both fixes — a `transform.spec.ts` test with `*` ordered before `@/*`, and a `runtime.spec.ts` test with both wildcard patterns present.