### PR TITLE
fix(unplugin-dts): separate publicRoot/entryRoot for TS 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "semver": "^7.7.1",
     "tsx": "^4.19.3",
     "typescript": "5.8.3",
+    "typescript-v6": "npm:typescript@^6.0.0",
     "unbuild": "^3.5.0",
     "vite": "^6.3.3",
     "vitest": "^4.1.5",

--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -282,16 +282,22 @@ export class Runtime {
     // TS 6.0 changed the default rootDir to dirname(tsconfig) instead of the common
     // ancestor of source files, so publicRoot and entryRoot must be computed separately.
     const sourcePublicPath = queryPublicPath(emittableSourceFiles)
+    const useTs6ImplicitRootDir =
+      !compilerOptions.rootDir &&
+      !(compilerOptions.composite && compilerOptions.configFilePath) &&
+      compare(ts.version, '6.0.0', '>=') &&
+      !!configPath
     let publicRoot = compilerOptions.rootDir
       ? ensureAbsolute(resolveConfigDir(compilerOptions.rootDir, root), root)
       : compilerOptions.composite && compilerOptions.configFilePath
         ? dirname(compilerOptions.configFilePath as string)
-        : compare(ts.version, '6.0.0', '>=') && configPath
+        : useTs6ImplicitRootDir
           ? dirname(configPath)
           : sourcePublicPath || (configPath ? dirname(configPath) : root)
     publicRoot = normalizePath(publicRoot)
 
-    let entryRoot = options.entryRoot || sourcePublicPath || publicRoot
+    let entryRoot =
+      options.entryRoot || (useTs6ImplicitRootDir ? sourcePublicPath || publicRoot : publicRoot)
     entryRoot = ensureAbsolute(entryRoot, root)
 
     const diagnostics = [

--- a/packages/unplugin-dts/src/core/runtime.ts
+++ b/packages/unplugin-dts/src/core/runtime.ts
@@ -5,6 +5,7 @@ import { cpus } from 'node:os'
 
 import ts from './ts-loader.cjs'
 import { createFilter } from '@rollup/pluginutils'
+import { compare } from 'compare-versions'
 import { green, red, yellow } from 'kolorist'
 import { loadProgramProcessor } from './processor'
 import { JsonResolver, SvelteResolver, VueResolver, parseResolvers } from './resolvers'
@@ -273,19 +274,24 @@ export class Runtime {
       )
     }
 
+    const emittableSourceFiles = program
+      .getSourceFiles()
+      .filter(maybeEmitted)
+      .map(sourceFile => sourceFile.fileName)
+
+    // TS 6.0 changed the default rootDir to dirname(tsconfig) instead of the common
+    // ancestor of source files, so publicRoot and entryRoot must be computed separately.
+    const sourcePublicPath = queryPublicPath(emittableSourceFiles)
     let publicRoot = compilerOptions.rootDir
       ? ensureAbsolute(resolveConfigDir(compilerOptions.rootDir, root), root)
       : compilerOptions.composite && compilerOptions.configFilePath
         ? dirname(compilerOptions.configFilePath as string)
-        : queryPublicPath(
-          program
-            .getSourceFiles()
-            .filter(maybeEmitted)
-            .map(sourceFile => sourceFile.fileName),
-        ) || (configPath ? dirname(configPath) : root)
+        : compare(ts.version, '6.0.0', '>=') && configPath
+          ? dirname(configPath)
+          : sourcePublicPath || (configPath ? dirname(configPath) : root)
     publicRoot = normalizePath(publicRoot)
 
-    let entryRoot = options.entryRoot || publicRoot
+    let entryRoot = options.entryRoot || sourcePublicPath || publicRoot
     entryRoot = ensureAbsolute(entryRoot, root)
 
     const diagnostics = [

--- a/packages/unplugin-dts/tests/runtime-ts6.spec.ts
+++ b/packages/unplugin-dts/tests/runtime-ts6.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -58,5 +58,50 @@ describe('runtime tests (TypeScript 6)', () => {
 
     expect(emittedFiles.has(normalizePath(resolve(tempDir, 'dist/index.d.ts')))).toBe(true)
     expect(emittedFiles.has(normalizePath(resolve(tempDir, 'dist/src/index.d.ts')))).toBe(false)
+  })
+
+  it('should bundle a non-empty entry declaration when rootDir is not explicitly set', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+
+    writeFileSync(
+      resolve(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+        types: 'dist/index.d.ts',
+      }),
+    )
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ESNext',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+        },
+        include: ['src/**/*'],
+      }),
+    )
+
+    mkdirSync(resolve(tempDir, 'src'), { recursive: true })
+    writeFileSync(resolve(tempDir, 'src', 'index.ts'), 'export const foo = 1\n')
+
+    const runtime = await Runtime.toInstance({
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      entries: {
+        index: resolve(tempDir, 'src/index.ts'),
+      },
+    })
+
+    await runtime.transform(resolve(tempDir, 'src/index.ts'), '')
+    const emittedFiles = await runtime.emitOutput({ bundleTypes: true })
+
+    const indexDts = normalizePath(resolve(tempDir, 'dist/index.d.ts'))
+    const content = emittedFiles.get(indexDts) ?? readFileSync(indexDts, 'utf-8')
+
+    expect(content).toContain('foo')
+    expect(content.trim()).not.toBe('export { }')
   })
 })

--- a/packages/unplugin-dts/tests/runtime-ts6.spec.ts
+++ b/packages/unplugin-dts/tests/runtime-ts6.spec.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// typescript-v6 is "npm:typescript@^6" — provides real TS 6 compilation behaviour
+// where the default rootDir is dirname(tsconfig) not the source ancestor.
+vi.mock('../src/core/ts-loader.cjs', async () => {
+  const ts6 = await import('typescript-v6')
+  return { default: ts6.default ?? ts6 }
+})
+
+const { Runtime } = await import('../src/core/runtime')
+const { normalizePath } = await import('../src/core/utils')
+
+describe('runtime tests (TypeScript 6)', () => {
+  let tempDir: string
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should emit to dist/index.d.ts not dist/src/index.d.ts when rootDir is not explicitly set', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ESNext',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+        },
+        include: ['src/**/*'],
+      }),
+    )
+
+    mkdirSync(resolve(tempDir, 'src'), { recursive: true })
+    writeFileSync(resolve(tempDir, 'src', 'index.ts'), 'export const foo = 1\n')
+    writeFileSync(resolve(tempDir, 'src', 'helper.ts'), 'export const bar = 2\n')
+
+    const runtime = await Runtime.toInstance({
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      entries: {
+        index: resolve(tempDir, 'src/index.ts'),
+      },
+    })
+
+    expect(normalizePath((runtime as any).publicRoot)).toBe(normalizePath(tempDir))
+    expect(normalizePath((runtime as any).entryRoot)).toBe(normalizePath(resolve(tempDir, 'src')))
+
+    await runtime.transform(resolve(tempDir, 'src/index.ts'), '')
+    const emittedFiles = await runtime.emitOutput({ insertTypesEntry: false })
+
+    expect(emittedFiles.has(normalizePath(resolve(tempDir, 'dist/index.d.ts')))).toBe(true)
+    expect(emittedFiles.has(normalizePath(resolve(tempDir, 'dist/src/index.d.ts')))).toBe(false)
+  })
+})

--- a/packages/unplugin-dts/tests/runtime.spec.ts
+++ b/packages/unplugin-dts/tests/runtime.spec.ts
@@ -283,6 +283,48 @@ describe('runtime tests', () => {
     expect(emittedFiles.has(srcIndexDts)).toBe(false)
   })
 
+  it('should use explicit rootDir as the default entryRoot', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ESNext',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          rootDir: '.',
+          strict: true,
+        },
+        include: ['src/**/*'],
+      }),
+    )
+
+    mkdirSync(resolve(tempDir, 'src'), { recursive: true })
+    writeFileSync(resolve(tempDir, 'src', 'index.ts'), 'export const foo = 1\n')
+
+    const runtime = await Runtime.toInstance({
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      entries: {
+        index: resolve(tempDir, 'src/index.ts'),
+      },
+    })
+
+    const rootDir = normalizePath(tempDir)
+    expect(normalizePath((runtime as any).publicRoot)).toBe(rootDir)
+    expect(normalizePath((runtime as any).entryRoot)).toBe(rootDir)
+
+    await runtime.transform(resolve(tempDir, 'src/index.ts'), '')
+    const emittedFiles = await runtime.emitOutput({ insertTypesEntry: false })
+
+    const indexDts = normalizePath(resolve(tempDir, 'dist/index.d.ts'))
+    const srcIndexDts = normalizePath(resolve(tempDir, 'dist/src/index.d.ts'))
+
+    expect(emittedFiles.has(indexDts)).toBe(false)
+    expect(emittedFiles.has(srcIndexDts)).toBe(true)
+  })
+
   it('should add .js extension to synthetic entry imports for nodenext compatibility', async () => {
     tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
 

--- a/packages/unplugin-dts/tests/runtime.spec.ts
+++ b/packages/unplugin-dts/tests/runtime.spec.ts
@@ -241,6 +241,48 @@ describe('runtime tests', () => {
     expect(content).not.toContain("export * from './index'")
   })
 
+  it('should emit to dist/index.d.ts not dist/src/index.d.ts when rootDir is not explicitly set', async () => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
+
+    writeFileSync(
+      resolve(tempDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ESNext',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          strict: true,
+        },
+        include: ['src/**/*'],
+      }),
+    )
+
+    mkdirSync(resolve(tempDir, 'src'), { recursive: true })
+    writeFileSync(resolve(tempDir, 'src', 'index.ts'), 'export const foo = 1\n')
+    writeFileSync(resolve(tempDir, 'src', 'helper.ts'), 'export const bar = 2\n')
+
+    const runtime = await Runtime.toInstance({
+      root: tempDir,
+      tsconfigPath: 'tsconfig.json',
+      entries: {
+        index: resolve(tempDir, 'src/index.ts'),
+      },
+    })
+
+    const srcDir = normalizePath(resolve(tempDir, 'src'))
+    expect(normalizePath((runtime as any).publicRoot)).toBe(srcDir)
+    expect(normalizePath((runtime as any).entryRoot)).toBe(srcDir)
+
+    await runtime.transform(resolve(tempDir, 'src/index.ts'), '')
+    const emittedFiles = await runtime.emitOutput({ insertTypesEntry: false })
+
+    const indexDts = normalizePath(resolve(tempDir, 'dist/index.d.ts'))
+    const srcIndexDts = normalizePath(resolve(tempDir, 'dist/src/index.d.ts'))
+
+    expect(emittedFiles.has(indexDts)).toBe(true)
+    expect(emittedFiles.has(srcIndexDts)).toBe(false)
+  })
+
   it('should add .js extension to synthetic entry imports for nodenext compatibility', async () => {
     tempDir = mkdtempSync(resolve(tmpdir(), 'unplugin-dts-'))
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      typescript-v6:
+        specifier: npm:typescript@^6.0.0
+        version: typescript@6.0.3
       unbuild:
         specifier: ^3.5.0
         version: 3.6.0(typescript@5.8.3)(vue-tsc@2.2.12(typescript@5.8.3))(vue@3.5.18(typescript@5.8.3))
@@ -5079,6 +5082,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -6721,6 +6729,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.38.0
       eslint-visitor-keys: 4.2.1
+
+  '@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.7.3))':
+    dependencies:
+      valibot: 1.0.0(typescript@5.7.3)
 
   '@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.8.3))':
     dependencies:
@@ -9948,7 +9960,7 @@ snapshots:
   rolldown@1.0.0-beta.8(typescript@5.7.3):
     dependencies:
       '@oxc-project/types': 0.65.0
-      '@valibot/to-json-schema': 1.0.0(valibot@1.0.0(typescript@5.8.3))
+      '@valibot/to-json-schema': 1.0.0(valibot@1.0.0(typescript@5.7.3))
       ansis: 3.17.0
       valibot: 1.0.0(typescript@5.7.3)
     optionalDependencies:
@@ -10653,6 +10665,8 @@ snapshots:
   typescript@5.8.2: {}
 
   typescript@5.8.3: {}
+
+  typescript@6.0.3: {}
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
Hey, sorry for opening a new PR! A regression was accidentally reintroduced in [57b6278](https://github.com/qmhc/unplugin-dts/commit/57b6278f69d4fd057a2658ccaea6ff45166f8405) — it reverted the TS 6.0 `publicRoot` fix from [b0a695e](https://github.com/qmhc/unplugin-dts/commit/b0a695e648703bc814e15167583569d99d3f9fdd) as a side effect of the alias fix, re-introducing #467. This PR is to properly fix that up.

## Summary

- `b0a695e` correctly set `publicRoot = dirname(tsconfig)` for TS 6.0 so `outputFiles` keys match TS's emission paths, but left `entryRoot` falling back to `publicRoot` — causing declarations to land at `dist/src/index.d.ts` instead of `dist/index.d.ts`
- `57b6278` reverted the TS 6.0 branch entirely as a side effect, restoring correct output paths but re-introducing the original #467 regression (bundleTypes empty module on TS 6.0)
- This fix restores the `compare(ts.version, '6.0.0', '>=')` branch for `publicRoot`, but computes `entryRoot` independently from `queryPublicPath(sourceFiles)` so output paths stay correct for both TS 5 and TS 6

## Test plan

- [x] `runtime.spec.ts` — TS 5.x path asserts `publicRoot === entryRoot === src/`
- [x] `runtime-ts6.spec.ts` — new spec mocks `ts-loader` with `typescript-v6` (`npm:typescript@^6`) to run the TS 6.0 code path; asserts `publicRoot = dirname(tsconfig)`, `entryRoot = src/`, output at `dist/index.d.ts` not `dist/src/index.d.ts`

Generated with [Claude Code](https://claude.com/claude-code)